### PR TITLE
Allow SSDP discovery to work even when the socket is being listened to by another application

### DIFF
--- a/lib/simple_upnp/discovery.rb
+++ b/lib/simple_upnp/discovery.rb
@@ -38,8 +38,9 @@ module SimpleUpnp
     def self.open_socket(&block)
       begin
         socket = UDPSocket.new
-        socket.bind('', SSDP_PORT)
+        socket.setsockopt(Socket::SOL_SOCKET, Socket::SO_REUSEADDR, [1].pack('i'))
         socket.setsockopt(Socket::IPPROTO_IP, Socket::IP_TTL, [1].pack('i'))
+        socket.bind('', SSDP_PORT)
         socket.send(M_SEARCH, 0, SSDP_ADDR, SSDP_PORT)
         yield socket
       ensure


### PR DESCRIPTION
Upon starting a find, simple_upnp crashes because it appear something else is already listening on the same port on my computer.

```
/Users/Kim/.rvm/gems/ruby-2.0.0-p247/gems/simple_upnp-0.0.4/lib/simple_upnp/discovery.rb:42:in `bind': Address already in use - bind(2) (Errno::EADDRINUSE)
    from /Users/Kim/.rvm/gems/ruby-2.0.0-p247/gems/simple_upnp-0.0.4/lib/simple_upnp/discovery.rb:42:in `open_socket'
    from /Users/Kim/.rvm/gems/ruby-2.0.0-p247/gems/simple_upnp-0.0.4/lib/simple_upnp/discovery.rb:28:in `find'
```

Setting the socket option SO_REUSEADDR allows the socket to be listened to even if another application is already listening on the same host and port. In practice, this means both applications listening will receive packets on the socket, so it won’t interfere with whatever other application is listening on the socket.
